### PR TITLE
Temporary fix to prevent python script from erasing versions in confi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [v1.1.0] - 2025-09-05
+### Fixed
+- Resolved an issue where `collect.py` was overwriting `afs/www/config.js` after firmware sync.
+  - Added automatic backup of `config.js` before running `collect.py`.
+  - After `collect.py` completes, `config.js` is restored from backup.
+  - This ensures the latest firmware versions remain publishable and prevents accidental corruption of the patched config.
+
+### Notes
+- This is a **temporary workaround** until upstream AREDN addresses [ticketed bug](https://github.com/drcit-lab42/aredn-firmware-sync/issues/5).
+- Since all files are refreshed on each rsync, this solution is safe and has minimal overhead.
+
 
 ## [v1.0.0-rc.2] - 2025-08-26
-
 ### Fixed
 - Corrected `collect.py` execution to run from `$ROOT` instead of hard-coded path.
 - Ensured firmware indexes are regenerated properly when the sync script runs.
 
 
 ## [v1.0.0-rc.1] - 2025-08-25
-
 ### Added
 - First release candidate of the AREDN Firmware Sync Script.
 - Automated sync from upstream AREDN firmware repository using rsync.

--- a/aredn_sync.sh
+++ b/aredn_sync.sh
@@ -47,7 +47,15 @@ else
   log "ERROR: config.js not found at $CONFIG_JS"
 fi
 
-# 3) run collect.py
+# 3) Backup config.js before collect.py
+# One the team at AREDNmesh fix the bug, this step will no longer be needed.
+COLLECT_BACKUP="${CONFIG_JS}.collect_backup.$(date +%F-%H%M%S)"
+if [[ -f "$CONFIG_JS" ]]; then
+  log "Creating backup of config.js before collect.py: $COLLECT_BACKUP"
+  cp -a "$CONFIG_JS" "$COLLECT_BACKUP"
+fi
+
+# 4) run collect.py
 if [ -x "$AFS/misc/collect.py" ]; then
   (
     cd "$ROOT" || { log "ERROR: ROOT dir not found: $ROOT"; exit 1; }
@@ -66,6 +74,16 @@ if [ -x "$AFS/misc/collect.py" ]; then
   log "collect.py complete"
 else
   log "WARNING: collect.py not found or not executable at $AFS/misc/collect.py"
+fi
+
+# 5) Restore config.js from backup
+# One the team at AREDNmesh fix the bug, this step will no longer be needed.
+if [[ -f "$COLLECT_BACKUP" ]]; then
+  log "Restoring config.js from backup: $COLLECT_BACKUP"
+  cp -a "$COLLECT_BACKUP" "$CONFIG_JS"
+  log "config.js restored successfully"
+else
+  log "WARNING: backup file not found for restoration: $COLLECT_BACKUP"
 fi
 
 log "=== run finished ==="


### PR DESCRIPTION
On step 3 of the [Creating a Local AREDN® Software Server](https://docs.arednmesh.org/en/latest/arednHow-toGuides/local-software-source.html), when running ```./afs/misc/collect.py  .  ./afs/www/```, the python script also makes changes to ```./afs/www/config.js``` which breaks the latest versions from publishing, despite just being downloaded during the rsync. This is a temporary fix, assuming AREDN will eventually respond to the [ticket](https://www.arednmesh.org/content/local-software-server-issues) and fix the script. It will makes a backup copy of config.js before running the python script and then restores it after the script completes.

This seemed to be the easiest way to fix it since all the files are replaced each time rsync is completed.

Resolves #5